### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,15 @@ language: android
 
 jdk:
   - oraclejdk8
+
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
 android:
   components:
   - tools

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ android:
   - android-sdk-license-[0-9a-f]{8}
 script: ./scripts/buildApp.sh
 before_install:
-- openssl aes-256-cbc -K $encrypted_218b70c0d15d_key -iv $encrypted_218b70c0d15d_iv
-  -in scripts/rtd.jks.enc -out scripts/rtd.jks -d
+ - ./scripts/before_install.sh
 before_deploy:
  - ./scripts/before_deploy.sh
 env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,17 +13,21 @@ android {
     }
 
     signingConfigs {
-        release {
-            storeFile file("../scripts/rtd.jks")
-            storePassword System.getenv("RTD_STORE_PASS")
-            keyAlias System.getenv("RTD_ALIAS")
-            keyPassword System.getenv("RTD_KEY_PASS")
+        if (file("../scripts/rtd.jks").exists()) {
+            release {
+                storeFile file("../scripts/rtd.jks")
+                storePassword System.getenv("RTD_STORE_PASS")
+                keyAlias System.getenv("RTD_ALIAS")
+                keyPassword System.getenv("RTD_KEY_PASS")
+            }
         }
     }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if (file("../scripts/rtd.jks").exists()) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard/zendesk-sdk.pro', 'proguard/zendesk-chat-sdk.pro'
         }

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [[ $encrypted_218b70c0d15d_key ]]; then
+    openssl aes-256-cbc -K $encrypted_218b70c0d15d_key -iv $encrypted_218b70c0d15d_iv -in scripts/rtd.jks.enc -out scripts/rtd.jks -d
+fi


### PR DESCRIPTION
Update `.travis.yml` to allow PRs from forks to be built.
See [CI Environment for Android Projects](https://docs.travis-ci.com/user/languages/android/#CI-Environment-for-Android-Projects). Keystore decryption will now only happen if the environment variables are set.

EDIT: I also had to include 90d30dc from #51 - I will remove it from the other PR accordingly.

EDIT2: Instead of removing the decryption and deploy steps on Travis altogether (previous attempt), I simply moved the `before_install` step to an external script, which only executes the `openssl` command if the environment variables were decrypted (which won't be the case for PRs from forks).