### PR TITLE
Bump version code

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 27
 
-        versionCode 19
+        versionCode 20
         versionName "2.0.2"
     }
 


### PR DESCRIPTION
We've had a report that the Chat SDK is causing the Google Play Store to reject APKs due to some openssl vulnerability. I'm bumping the version code so I can do a dummy release (using our usual release mechanism, with correct signing etc), to upload that to the Play Store and see if I get the same issue. It won't be actually released, but it should show up any problems there. 

The versionCode update is needed for the dev console to recognise it as a valid new version. 