### PR TITLE
[SGA-417] Replace Github deploy key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ deploy:
   skip_cleanup: true
   provider: releases
   api_key:
-    secure: MNBI+eK7Aa4BCucvmxzzVlm/Tc4fyqdjv1iu5IqtjJc4vFUE3LvjBJ9d/lsQD89eavj8STMyONhbQ2+6JL6EKrfhulwwMVd5N//daLO9KA/xfEpIZO9z9RvP5VdqTDDTYrJ52HrB/MC+v5AqxxZUfk7XVjxRmAvefGWhVtlZ8CY=
+    secure: $zdGithubDeployKey # This env var is configured in https://travis-ci.org/zendesk/sdk_demo_app_android/settings using our Mobile CI Github service account
   file:
     - ./app/build/outputs/apk/debug/app-debug.apk
     - ./app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
## Changes
* Remove the encrypted Github access token used as deploy key (the Github token has since been revoked)
* Read the access token from an env var on Travis instead. 

## Reviewers
@zendesk/adventure-android @zendesk/two-brothers-android 

## References
[Jira](https://zendesk.atlassian.net/browse/SGA-417)